### PR TITLE
use custom emoji instead of link to image

### DIFF
--- a/lib/lita/handlers/hal_9000.rb
+++ b/lib/lita/handlers/hal_9000.rb
@@ -27,8 +27,7 @@ module Lita
       end
 
       def format_reply(message:)
-        "I'm sorry, I can't do that @#{message.user.mention_name} " \
-          "http://bit.ly/11FZRaq"
+        ":hal9000: I'm sorry, I can't do that @#{message.user.mention_name} "
       end
 
     end


### PR DESCRIPTION
If you set up a custom emoji in Slack for `:hal9000:` using the image linked to in the original plugin http://s29.postimg.org/en1j0grer/200px_HAL9000_svg.png ![](http://s29.postimg.org/en1j0grer/200px_HAL9000_svg.png) you'll have a nicer time.
